### PR TITLE
Fix potential bug when cancelling requests in UITableView didEndDispl…

### DIFF
--- a/EssentialApp/EssentialAppTests/Feed UI/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/Feed UI/FeedUIIntegrationTests.swift
@@ -310,6 +310,22 @@ final class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(sut.errorMessage, nil)
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.simulateAppearance()
+        sut.tableView.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+        RunLoop.current.run(until: Date()+1)
+    }
+    
     // MARK: - HELPERS
     
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: FeedViewController, loader: LoaderSpy) {

--- a/EssentialApp/EssentialAppTests/Feed UI/FeedViewControllerTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Feed UI/FeedViewControllerTests+Assertions.swift
@@ -12,6 +12,9 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
 
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -16,6 +16,8 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     private var onViewIsAppearing: ((FeedViewController) -> Void)?
     public var delegate: FeedViewControllerDelegate?
     
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+    
     @IBOutlet private(set) public var errorView: ErrorView?
     
     private var tableModel = [FeedImageCellController]() {
@@ -44,6 +46,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -88,10 +91,13 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
…ayingCell method - This method is invoked after calling `reloadData`, so we'd be cancelling requests in the wrong models or crash in case the model has less items than the previous model